### PR TITLE
Issue #27 - Temporary workaround for issue found on scoped pipe rifle…

### DIFF
--- a/Fallout4VR_Body.vcxproj
+++ b/Fallout4VR_Body.vcxproj
@@ -79,13 +79,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <LibraryPath>lib_debug;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-    <IncludePath>C:\Users\rolli\source\repos\f4sevr\src\f4sevr;C:\Users\rolli\source\repos\f4sevr\src;include;$(IncludePath)</IncludePath>
+    <IncludePath>E:\Vortex Mods\Manual\Fallout4VR\f4sevr_0_6_20\src\f4sevr;E:\Vortex Mods\Manual\Fallout4VR\f4sevr_0_6_20\src;include;$(IncludePath)</IncludePath>
     <TargetName>FRIK</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>true</LinkIncremental>
     <LibraryPath>lib;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-    <IncludePath>C:\Users\rolli\source\repos\f4sevr\src\f4sevr;C:\Users\rolli\source\repos\f4sevr\src;include;$(IncludePath) </IncludePath>
+    <IncludePath>E:\Vortex Mods\Manual\Fallout4VR\f4sevr_0_6_20\src\f4sevr;E:\Vortex Mods\Manual\Fallout4VR\f4sevr_0_6_20\src;include;$(IncludePath)</IncludePath>
     <TargetName>FRIK</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -139,7 +139,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(TargetPath)" "E:\fvre\mods\FRIK\F4SE\Plugins" /Y</Command>
+      <Command>copy "$(TargetPath)" "E:\Steam\SteamApps\common\Fallout 4 VR\Data\F4SE\Plugins" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -166,7 +166,7 @@
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(TargetPath)" "E:\fvre\mods\FRIK\F4SE\Plugins" /Y</Command>
+      <Command>copy "$(TargetPath)" "E:\Steam\SteamApps\common\Fallout 4 VR\Data\F4SE\Plugins" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Fallout4VR_Body.vcxproj.filters
+++ b/Fallout4VR_Body.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClCompile Include="SmoothMovement.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="HandPose.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\version.h">

--- a/Skeleton.cpp
+++ b/Skeleton.cpp
@@ -2173,7 +2173,9 @@ namespace F4VRBody
 			NiNode* weap = getNode("Weapon", (*g_player)->firstPersonSkeleton);
 
 			if (weap) {
+				auto localRotation = weap->m_localTransform.rot;
 				weap->m_localTransform = _weapSave;
+				weap->m_localTransform.rot = localRotation;
 				NiPoint3 offset = NiPoint3(-0.94, 0, 0);
 				NiNode* weapOffset = getNode("WeaponOffset", weap);
 


### PR DESCRIPTION
… causing bad rifle orientation.

This seems to fix the issue I had reported, though I'm pretty sure it does throw off some weapon orientations a bit. The most important thing to me is that it makes scopes usable so I'll be playing like this for the time being.

I won't pretend to totally understand all that's going on, but it seems to have something to do with the weapon rotation you apply in the setArms function before the IK solution. Maybe. I guess.

Hope this helps you figure it out!