### PR TITLE
Add fast pipBoy disabling and full repositioning, and improve weaponOffsets

### DIFF
--- a/F4VRBody.cpp
+++ b/F4VRBody.cpp
@@ -71,10 +71,12 @@ namespace F4VRBody {
 	float c_gripLetGoThreshold = 15.0f;
 	bool c_isLookingThroughScope = false;
 	bool c_pipBoyButtonMode = false;
+	bool c_pipBoyAllowMovementNotLooking = true;
 	int c_pipBoyButtonArm = 0;   // 0 for left 1 for right
 	int c_pipBoyButtonID = vr::EVRButtonId::k_EButton_Grip; // grip button is 2
 	int c_gripButtonID = vr::EVRButtonId::k_EButton_Grip; // 2
 	int c_holdDelay = 1000; // 1000 ms
+	int c_pipBoyOffDelay = 5000; // 5000 ms
 	int c_repositionButtonID = vr::EVRButtonId::k_EButton_SteamVR_Trigger; //33
 	int c_defaultPositionButtonID = vr::EVRButtonId::k_EButton_A; // 7
 	bool c_enableOffHandGripping = true;
@@ -163,8 +165,10 @@ namespace F4VRBody {
 		c_handUI_Z = ini.GetDoubleValue("Fallout4VRBody", "handUI_Z", 0.0);
 		c_hideHead = ini.GetBoolValue("Fallout4VRBody", "HideTheHead");
 		c_pipBoyLookAtGate = ini.GetDoubleValue("Fallout4VRBody", "PipBoyLookAtThreshold", 0.7);
+		c_pipBoyOffDelay = (int)ini.GetLongValue("Fallout4VRBody", "PipBoyOffDelay", 5000);
 		c_gripLetGoThreshold = ini.GetDoubleValue("Fallout4VRBody", "GripLetGoThreshold", 15.0f);
 		c_pipBoyButtonMode =             ini.GetBoolValue("Fallout4VRBody", "OperatePipboyWithButton", false);
+		c_pipBoyAllowMovementNotLooking = ini.GetBoolValue("Fallout4VRBody", "AllowMovementWhenNotLookingAtPipboy", true);
 		c_pipBoyButtonArm = (int)ini.GetLongValue("Fallout4VRBody", "OperatePipboyWithButtonArm", 0);
 		c_pipBoyButtonID = (int)ini.GetLongValue("Fallout4VRBody", "OperatePipboyWithButtonID", vr::EVRButtonId::k_EButton_Grip); //2
 		c_gripButtonID = (int)ini.GetLongValue("Fallout4VRBody", "GripButtonID", vr::EVRButtonId::k_EButton_Grip); // 2

--- a/F4VRBody.h
+++ b/F4VRBody.h
@@ -47,10 +47,12 @@ namespace F4VRBody {
 	extern float c_gripLetGoThreshold;
 	extern bool c_isLookingThroughScope;
 	extern bool c_pipBoyButtonMode;
+	extern bool c_pipBoyAllowMovementNotLooking;
 	extern int c_pipBoyButtonArm;
 	extern int c_pipBoyButtonID;
 	extern int c_gripButtonID;
 	extern int c_holdDelay;
+	extern int c_pipBoyOffDelay;
 	extern int c_repositionButtonID;
 	extern int c_defaultPositionButtonID;
 	extern bool c_enableOffHandGripping;

--- a/Skeleton.cpp
+++ b/Skeleton.cpp
@@ -2840,7 +2840,7 @@ namespace F4VRBody
 				if (!c_enableGripButtonToGrap) {
 					_offHandGripping = true;
 				}
-				else if (reg & vr::ButtonMaskFromId((vr::EVRButtonId)c_gripButtonID)) {
+				else if (!_pipboyStatus && reg & vr::ButtonMaskFromId((vr::EVRButtonId)c_gripButtonID)) {
 					if (_offHandGripping || !_hasLetGoGripButton) {
 						return;
 					}

--- a/Skeleton.cpp
+++ b/Skeleton.cpp
@@ -2726,18 +2726,30 @@ namespace F4VRBody
 							_hasLetGoRepositionButton = false;
 							_repositionButtonHoldStart = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 							_startFingerBonePos = rt->transforms[boneTreeMap[offHandBone]].world.pos - _curPos;
-							_MESSAGE("Reposition Button Hold start: weapon %s", weapname);
+							_MESSAGE("Reposition Button Hold start: weapon %s mode: %d", weapname, _repositionMode);
 						}
 					}
 					else{
+						if (!_repositionModeSwitched && reg & vr::ButtonMaskFromId((vr::EVRButtonId)c_defaultPositionButtonID)) {
+							_repositionMode = static_cast<repositionMode>((_repositionMode + 1) % (repositionMode::total + 1));
+							vrhook->StartHaptics(c_leftHandedMode ? 0 : 1, 0.1 * (_repositionMode + 1), 0.3);
+							_repositionModeSwitched = true;
+							_MESSAGE("Reposition Mode Switch: weapon %s %d ms mode: %d", weapname, _pressLength, _repositionMode);
+						}
+						else if (_repositionModeSwitched && !(reg & vr::ButtonMaskFromId((vr::EVRButtonId)c_defaultPositionButtonID))) {
+							_repositionModeSwitched = false;
+						}
 						_pressLength = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - _repositionButtonHoldStart;
-						if (reg & vr::ButtonMaskFromId((vr::EVRButtonId)c_repositionButtonID) && _pressLength > c_holdDelay) {
-							vrhook->StartHaptics(c_leftHandedMode? 0 : 1, 0.05, 0.3);
-						} else if (!(reg & vr::ButtonMaskFromId((vr::EVRButtonId)c_repositionButtonID))) {
+						if (!_repositionHapticFired && reg & vr::ButtonMaskFromId((vr::EVRButtonId)c_repositionButtonID) && _pressLength > c_holdDelay) {
+							vrhook->StartHaptics(c_leftHandedMode? 0 : 1, 0.1 * (_repositionMode + 1), 0.3);
+							_repositionHapticFired = true;
+						}
+						else if (!(reg & vr::ButtonMaskFromId((vr::EVRButtonId)c_repositionButtonID))) {
 							_repositionButtonHolding = false;
 							_hasLetGoRepositionButton = true;
+							_repositionHapticFired = false;
 							_endFingerBonePos = rt->transforms[boneTreeMap[offHandBone]].world.pos - _curPos;
-							_MESSAGE("Reposition Button Hold stop: weapon %s %d ms", weapname, _pressLength);
+							_MESSAGE("Reposition Button Hold stop: weapon %s %d ms mode: %d", weapname, _pressLength, _repositionMode);
 						}
 					}
 
@@ -2762,11 +2774,23 @@ namespace F4VRBody
 						fingerBonePos = rt->transforms[boneTreeMap[offHandBone]].world.pos;
 						bodyPos = _curPos;
 						if (_repositionButtonHolding) {
+							// this is for a preview of the move. The preview happens one frame before we detect the release so must be processed separately.
 							auto end = fingerBonePos - _curPos;
 							auto change = vec3_len(end) > vec3_len(_startFingerBonePos)? vec3_len(end - _startFingerBonePos) : -vec3_len(end - _startFingerBonePos);
 							if (change != 0) {
-								weap->m_localTransform.pos.x += change;
-								_DMESSAGE("Updating x translation for %s by %f to %f", weapname, change, weap->m_localTransform.pos.x);
+								switch (_repositionMode) {
+								case x:
+									weap->m_localTransform.pos.x += change;
+									_DMESSAGE("Updating X translation for %s by %f to %f", weapname, change, weap->m_localTransform.pos.x);
+									break;
+								case y:
+									weap->m_localTransform.pos.y += change;
+									_DMESSAGE("Updating Y translation for %s by %f to %f", weapname, change, weap->m_localTransform.pos.y);
+									break;
+								case z:
+									weap->m_localTransform.pos.z += change;
+									_DMESSAGE("Updating Z translation for %s by %f to %f", weapname, change, weap->m_localTransform.pos.z);
+								}
 							}
 						}
 						//_hasLetGoRepositionButton is always one frame after _repositionButtonHolding
@@ -2779,14 +2803,30 @@ namespace F4VRBody
 							writeOffsetJson();
 						}else if (_hasLetGoRepositionButton && _pressLength > 0 && _pressLength > c_holdDelay) {
 							auto change = vec3_len(_endFingerBonePos) > vec3_len(_startFingerBonePos) ? vec3_len(_endFingerBonePos - _startFingerBonePos) : -vec3_len(_endFingerBonePos - _startFingerBonePos);
-							weap->m_localTransform.pos.x += change;
-							_MESSAGE("Saving position translation for %s from %f -> %f", weapname, _customTransform.pos.x, weap->m_localTransform.pos.x);
-							_customTransform.pos.x = weap->m_localTransform.pos.x;
+							switch (_repositionMode) {
+							case x:
+								weap->m_localTransform.pos.x += change;
+								_MESSAGE("Saving X position translation for %s from %f -> %f: powerArmor: %d", weapname, _customTransform.pos.x, weap->m_localTransform.pos.x, _inPowerArmor);
+								_customTransform.pos.x = weap->m_localTransform.pos.x;
+								break;
+							case y:
+								weap->m_localTransform.pos.y += change;
+								_MESSAGE("Saving Y position translation for %s from %f -> %f: powerArmor: %d", weapname, _customTransform.pos.y, weap->m_localTransform.pos.y, _inPowerArmor);
+								_customTransform.pos.y = weap->m_localTransform.pos.y;
+								break;
+							case z:
+								weap->m_localTransform.pos.z += change;
+								_MESSAGE("Saving Z position translation for %s from %f -> %f: powerArmor: %d", weapname, _customTransform.pos.z, weap->m_localTransform.pos.z, _inPowerArmor);
+								_customTransform.pos.z = weap->m_localTransform.pos.z;
+							}
 							_hasLetGoRepositionButton = false;
 							_useCustomWeaponOffset = true;
 							g_weaponOffsets->addOffset(weapname, _customTransform, _inPowerArmor);
 							writeOffsetJson();
 						}
+						else if (_useCustomWeaponOffset 
+							&& !(_hasLetGoRepositionButton || _repositionButtonHolding) // do not allow defaults when handling reposition
+							&& reg & vr::ButtonMaskFromId((vr::EVRButtonId)c_defaultPositionButtonID)) {
 							_MESSAGE("Resetting grip to defaults for %s: powerArmor: %d", weapname, _inPowerArmor);
 							_useCustomWeaponOffset = false;
 							g_weaponOffsets->deleteOffset(weapname, _inPowerArmor);

--- a/Skeleton.h
+++ b/Skeleton.h
@@ -253,6 +253,12 @@ namespace F4VRBody
 		float getNeckPitch();
 		float getBodyPitch();
 
+		enum repositionMode {
+			x = 0, // down the barrel
+			z, // vertically up and down
+			y, // laterally left and right
+			total = y
+		};
 
 	private:
 		BSFadeNode* _root;
@@ -323,6 +329,9 @@ namespace F4VRBody
 
 		bool _offHandGripping;
 		bool _repositionButtonHolding = false;
+		bool _repositionHapticFired = false;
+		bool _repositionModeSwitched = false;
+		repositionMode _repositionMode = repositionMode::x;
 		uint64_t _repositionButtonHoldStart = 0;
 		NiPoint3 _startFingerBonePos = NiPoint3(0, 0, 0);
 		NiPoint3 _endFingerBonePos = NiPoint3(0, 0, 0);

--- a/Skeleton.h
+++ b/Skeleton.h
@@ -330,5 +330,6 @@ namespace F4VRBody
 		bool _hasLetGoRepositionButton = false;
 		std::string _lastWeapon = "";
 		Quaternion _aimAdjust;
+		uint64_t _lastLookingAtPip = 0;
 	};
 }

--- a/weaponOffset.cpp
+++ b/weaponOffset.cpp
@@ -1,9 +1,8 @@
 #include "weaponOffset.h"
 
-#include "include/json.hpp"
-
 #include <iostream>
 #include <fstream>
+#include <filesystem>
 
 using json = nlohmann::json;
 
@@ -40,14 +39,30 @@ namespace F4VRBody {
 			delete g_weaponOffsets;
 		}
 		g_weaponOffsets = new WeaponOffset();
+		loadOffsetJsonFile(); //load default list if it exists
+		if (!(std::filesystem::exists(offsetsPath) && std::filesystem::is_directory(offsetsPath)))
+			std::filesystem::create_directory(offsetsPath);
+		for (const auto& file : std::filesystem::directory_iterator(offsetsPath)) {
+			std::wstring path = L"";
+			try {
+				path = file.path().wstring();
+			}
+			catch (std::exception& e) {
+				_WARNING("Unable to convert path to string: %s", e.what());
+			}
+			if (file.exists() && !file.is_directory())
+				loadOffsetJsonFile(file.path().string());
+			}
+	}
+	void loadOffsetJsonFile(const std::string &file) {
 
 		json weaponJson;
 		std::ifstream inF;
 
-		inF.open(".\\Data\\F4SE\\plugins\\FRIK_weapon_offsets.json", std::ios::in);
+		inF.open(file, std::ios::in);
 
 		if (inF.fail()) {
-			_MESSAGE("cannot open FRIK_weapon_offsets.json!!!");
+			_WARNING("cannot open %s", file.c_str());
 			inF.close();
 			return;
 		}
@@ -57,7 +72,7 @@ namespace F4VRBody {
 		}
 		catch (json::parse_error& ex)
 		{
-			_MESSAGE("cannot open FRIK_weapon_offsets.json: parse error at byte %d", ex.byte);
+			_MESSAGE("cannot open %s: parse error at byte %d", file.c_str(), ex.byte);
 			inF.close();
 			return;
 		}
@@ -77,31 +92,39 @@ namespace F4VRBody {
 			g_weaponOffsets->addOffset(key, data);
 
 		}
-		_MESSAGE("Successfully loaded %d offsets from FRIK_weapon_offsets.json", g_weaponOffsets->getSize());
+		_MESSAGE("Successfully loaded %d offsets from %s: total %d", weaponJson.size(), file.c_str(), g_weaponOffsets->getSize());
 	}
 
-	void writeOffsetJson() {
-
-		json weaponJson;
+	void saveOffsetJsonFile(const json& weaponJson, const std::string& file) {
 		std::ofstream outF;
 
-		outF.open(".\\Data\\F4SE\\plugins\\FRIK_weapon_offsets.json", std::ios::out);
+		outF.open(file, std::ios::out);
 
 		if (outF.fail()) {
-			_MESSAGE("cannot open FRIK_weapon_offsets.ini for writing!!!");
+			_MESSAGE("cannot open %s for writing", file.c_str());
 			return;
 		}
 
+		try {
+			outF << std::setw(4) << weaponJson;
+			outF.close();
+		}catch (std::exception& e) {
+			outF.close();
+			_WARNING("Unable to save json %s: %s", file.c_str(), e.what());
+		}
+	}
+	void writeOffsetJson() {
+
+		std::string file;
+
 		for (auto& item : g_weaponOffsets->offsets) {
+			json weaponJson;
 			weaponJson[item.first]["rotation"] = item.second.rot.arr;
 			weaponJson[item.first]["x"] = item.second.pos.x;
 			weaponJson[item.first]["y"] = item.second.pos.y;
 			weaponJson[item.first]["z"] = item.second.pos.z;
 			weaponJson[item.first]["scale"] = item.second.scale;
+			saveOffsetJsonFile(weaponJson, offsetsPath + "\\" + item.first + ".json");
 		}
-
-		outF << weaponJson;
-		outF.close();
 	}
-
 }

--- a/weaponOffset.cpp
+++ b/weaponOffset.cpp
@@ -11,23 +11,25 @@ namespace F4VRBody {
 
 	WeaponOffset* g_weaponOffsets = nullptr;
 
-	std::optional<NiTransform> WeaponOffset::getOffset(const std::string &name) {
+	std::optional<NiTransform> WeaponOffset::getOffset(const std::string &name, const bool powerArmor) {
 
-		auto it = offsets.find(name);
+		auto it = offsets.find(powerArmor ? name + powerArmorSuffix : name);
 		if (it == offsets.end()) {
+			if (powerArmor) //check without PA
+				return getOffset(name); 
 			return { };
 		}
 
 		return it->second;
 	}
 
-	void WeaponOffset::addOffset(const std::string &name, NiTransform someData) {
-		offsets[name] = someData;
+	void WeaponOffset::addOffset(const std::string &name, NiTransform someData, const bool powerArmor) {
+		offsets[powerArmor ? name + powerArmorSuffix : name] = someData;
 	}
 
 
-	void WeaponOffset::deleteOffset(const std::string& name) {
-		offsets.erase(name);
+	void WeaponOffset::deleteOffset(const std::string& name, const bool powerArmor) {
+		offsets.erase(powerArmor ? name + powerArmorSuffix : name);
 	}
 
 	std::size_t WeaponOffset::getSize() {

--- a/weaponOffset.h
+++ b/weaponOffset.h
@@ -2,6 +2,7 @@
 
 #include "f4se/NiObjects.h"
 #include <optional>
+#include "include/json.hpp"
 
 
 
@@ -23,8 +24,13 @@ namespace F4VRBody {
 		std::map<std::string, NiTransform> offsets;
 	};
 
+	static const std::string defaultJson{ ".\\Data\\F4SE\\plugins\\FRIK_weapon_offsets.json" };
+	static const std::string offsetsPath{ ".\\Data\\F4SE\\plugins\\FRIK_weapon_offsets" };
+
 	void readOffsetJson();
+	void loadOffsetJsonFile(const std::string& file = defaultJson);
 	void writeOffsetJson();
+	void saveOffsetJsonFile(const nlohmann::json& weaponJson, const std::string& file = defaultJson);
 
 	extern WeaponOffset* g_weaponOffsets;
 }

--- a/weaponOffset.h
+++ b/weaponOffset.h
@@ -16,14 +16,15 @@ namespace F4VRBody {
 			offsets.clear();
 		}
 
-		std::optional<NiTransform> getOffset(const std::string &name);
-		void addOffset(const std::string &name, NiTransform someData);
-		void deleteOffset(const std::string& name);
+		std::optional<NiTransform> getOffset(const std::string &name, const bool powerArmor = false);
+		void addOffset(const std::string &name, NiTransform someData, const bool powerArmor = false);
+		void deleteOffset(const std::string& name, const bool powerArmor = false);
 		std::size_t getSize();
 
 		std::map<std::string, NiTransform> offsets;
 	};
 
+	static const std::string powerArmorSuffix{ "-PowerArmor" };
 	static const std::string defaultJson{ ".\\Data\\F4SE\\plugins\\FRIK_weapon_offsets.json" };
 	static const std::string offsetsPath{ ".\\Data\\F4SE\\plugins\\FRIK_weapon_offsets" };
 


### PR DESCRIPTION
See individual commits for items and instructions on how to access.

Weapon angle positioning is just clicking left trigger while in offhand gripping mode. This could conflict with people who turn on and off their flashlight while offhand gripping, but I'm either leaving it on or off anyway.  Resetting weapon positioning to defaults is A button (c_defaultPositionButtonID) while offhand gripping.