### PR TITLE
Fixes for reposition mode

### DIFF
--- a/Fallout4VR_Body.vcxproj
+++ b/Fallout4VR_Body.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -79,13 +79,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <LibraryPath>lib_debug;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-    <IncludePath>C:\Users\rolli\source\repos\f4sevr\src\f4sevr;C:\Users\rolli\source\repos\f4sevr\src;include;$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)..\f4sevr\src\f4sevr;$(SolutionDir)..\f4sevr\src;include;$(IncludePath)</IncludePath>
     <TargetName>FRIK</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>true</LinkIncremental>
     <LibraryPath>lib;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-    <IncludePath>C:\Users\rolli\source\repos\f4sevr\src\f4sevr;C:\Users\rolli\source\repos\f4sevr\src;include;$(IncludePath) </IncludePath>
+    <IncludePath>$(SolutionDir)..\f4sevr\src\f4sevr;$(SolutionDir)..\f4sevr\src;include;$(IncludePath)</IncludePath>
     <TargetName>FRIK</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/Skeleton.cpp
+++ b/Skeleton.cpp
@@ -2809,6 +2809,8 @@ namespace F4VRBody
 								weap->m_localTransform.pos.y = _offsetPreview.y; // y, z are cumulative
 								weap->m_localTransform.pos.z = _offsetPreview.z;
 								break;
+							case resetToDefault:
+								break;
 							}
 						}
 						//_hasLetGoRepositionButton is always one frame after _repositionButtonHolding
@@ -2827,19 +2829,17 @@ namespace F4VRBody
 								weap->m_localTransform.pos.y = _offsetPreview.y; // y, z are cumulative
 								weap->m_localTransform.pos.z = _offsetPreview.z;
 								_customTransform.pos = weap->m_localTransform.pos;
+								_useCustomWeaponOffset = true;
+								g_weaponOffsets->addOffset(weapname, _customTransform, _inPowerArmor);
+								break;
+							case resetToDefault:
+								_MESSAGE("Resetting grip to defaults for %s: powerArmor: %d", weapname, _inPowerArmor);
+								_useCustomWeaponOffset = false;
+								g_weaponOffsets->deleteOffset(weapname, _inPowerArmor);
+								_repositionMode = weapon;
 								break;
 							}
 							_hasLetGoRepositionButton = false;
-							_useCustomWeaponOffset = true;
-							g_weaponOffsets->addOffset(weapname, _customTransform, _inPowerArmor);
-							writeOffsetJson();
-						}
-						else if (_useCustomWeaponOffset
-							&& !(_hasLetGoRepositionButton || _repositionButtonHolding) // do not allow defaults when handling reposition
-							&& reg & vr::ButtonMaskFromId((vr::EVRButtonId)c_offHandActivateButtonID)) {
-							_MESSAGE("Resetting grip to defaults for %s: powerArmor: %d", weapname, _inPowerArmor);
-							_useCustomWeaponOffset = false;
-							g_weaponOffsets->deleteOffset(weapname, _inPowerArmor);
 							writeOffsetJson();
 						}
 					}

--- a/Skeleton.cpp
+++ b/Skeleton.cpp
@@ -2931,6 +2931,7 @@ namespace F4VRBody
 					if (vrhook)
 						vrhook->StartHaptics(c_leftHandedMode ? 0 : 1, 0.1, 0.3);
 				}
+			// detect scope reposition buton being held near scope. Only has to start near scope.
 			if (handNearScope && !_repositionButtonHolding && handInput & vr::ButtonMaskFromId((vr::EVRButtonId)c_repositionButtonID)) { // repositioning
 				_repositionButtonHolding = true;
 				_hasLetGoRepositionButton = false;
@@ -2938,6 +2939,7 @@ namespace F4VRBody
 				_MESSAGE("Reposition Button Hold start: scope %s", scopeName);
 			}
 			else if (_repositionButtonHolding && !(handInput & vr::ButtonMaskFromId((vr::EVRButtonId)c_repositionButtonID))) {
+			// was in scope reposition mode and just released button, time to save
 				_repositionButtonHolding = false;
 				_hasLetGoRepositionButton = true;
 				_inRepositionMode = false;
@@ -2948,13 +2950,14 @@ namespace F4VRBody
 				_MESSAGE("Reposition Button Hold stop: scope %s %d ms", scopeName, _pressLength);
 			}
 			_pressLength = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - _repositionButtonHoldStart;
+			// repositioning does not require hand near scope
 			if (!_inRepositionMode && handInput & vr::ButtonMaskFromId((vr::EVRButtonId)c_repositionButtonID) && _pressLength > c_holdDelay) {
 				// enter reposition mode
 				if (vrhook)
 					vrhook->StartHaptics(c_leftHandedMode ? 0 : 1, 0.1, 0.3);
 				_inRepositionMode = true;
 			}
-			else { // in reposition mode
+			else if (_inRepositionMode) { // in reposition mode for better scopes
 				vr::VRControllerAxis_t axis_state = !(c_pipBoyButtonArm > 0) ? rightControllerState.rAxis[0] : leftControllerState.rAxis[0];
 				if (!_repositionModeSwitched && handInput & vr::ButtonMaskFromId((vr::EVRButtonId)c_offHandActivateButtonID)) {
 					if (vrhook)

--- a/Skeleton.h
+++ b/Skeleton.h
@@ -255,8 +255,9 @@ namespace F4VRBody
 		float getBodyPitch();
 
 		enum repositionMode {
-			weapon = 0, // weapon
-			total = weapon
+			weapon = 0, // move weapon
+			resetToDefault = 1, // reset to default and exit reposition mode
+			total = resetToDefault
 		};
 
 	private:

--- a/Skeleton.h
+++ b/Skeleton.h
@@ -255,10 +255,8 @@ namespace F4VRBody
 		float getBodyPitch();
 
 		enum repositionMode {
-			x = 0, // down the barrel
-			z, // vertically up and down
-			y, // laterally left and right
-			total = y
+			weapon = 0, // weapon
+			total = weapon
 		};
 
 	private:
@@ -332,10 +330,11 @@ namespace F4VRBody
 		bool _repositionButtonHolding = false;
 		bool _inRepositionMode = false;
 		bool _repositionModeSwitched = false;
-		repositionMode _repositionMode = repositionMode::x;
+		repositionMode _repositionMode = repositionMode::weapon;
 		uint64_t _repositionButtonHoldStart = 0;
 		NiPoint3 _startFingerBonePos = NiPoint3(0, 0, 0);
 		NiPoint3 _endFingerBonePos = NiPoint3(0, 0, 0);
+		NiPoint3 _offsetPreview = NiPoint3(0, 0, 0);
 		bool _hasLetGoGripButton;
 		bool _hasLetGoRepositionButton = false;
 		bool _hasLetGoZoomModeButton = false;


### PR DESCRIPTION
- Allows weapon offset change with analog stick
- Fix bug where reticle was always in reposition mode
- Weapon offset reset is now a mode within reposition mode. This should prevent people accidentally resetting weapon offsets unintentionally while just gripping the gun.

See commits for specific details