### PR TITLE
Fix PipBot scale not saved when save button is pressed.

### DIFF
--- a/Skeleton.cpp
+++ b/Skeleton.cpp
@@ -2857,6 +2857,14 @@ namespace F4VRBody
 					_isSaveButtonPressed = true;
 					c_IsHoloPipboy ? g_weaponOffsets->addOffset("HoloPipboyPosition", pbRoot->m_localTransform, Mode::normal) : g_weaponOffsets->addOffset("PipboyPosition", pbRoot->m_localTransform, Mode::normal);
 					writeOffsetJson();
+
+					// TODO: move save INI to common code instead or repeating it
+					// why do some buttons (glance, dumpen, model) save on toggle and not wait for save button?
+					_MESSAGE("Saving config to FRIK.ini");
+					CSimpleIniA ini;
+					SI_Error rc = ini.LoadFile(".\\Data\\F4SE\\plugins\\FRIK.ini");
+					rc = ini.SetDoubleValue("Fallout4VRBody", "PipboyScale", (double)_3rdPipboy->m_localTransform.scale);
+					rc = ini.SaveFile(".\\Data\\F4SE\\plugins\\FRIK.ini");
 				}
 				else if (!SaveButtonPressed) {
 					_isSaveButtonPressed = false;


### PR DESCRIPTION
Side note:
ini save code is duplicated which may create bugs in the future.
why not save to init only on save button?
I think it's a confusing user experience when some changes are saved immediately and some are not. Let's make it all work the same.