### PR TITLE
Fix blurry of 3D objects rendering

### DIFF
--- a/Fallout4VR_Body.vcxproj
+++ b/Fallout4VR_Body.vcxproj
@@ -139,8 +139,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(TargetPath)" "C:\Stuff\Fallout Modding\VR Essentials Overhaul\mods\FRIK alpha 71\F4SE\Plugins" /Y
-</Command>
+      <Command>copy "$(TargetPath)" "C:\mo2\fo4vr\mods\FRIK\F4SE\Plugins" /Y
+copy "$(TargetPath)" "C:\mo2\mgc\mods\FRIK alpha 64\F4SE\Plugins" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -167,8 +167,8 @@
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(TargetPath)" "C:\Stuff\Fallout Modding\VR Essentials Overhaul\mods\FRIK alpha 71\F4SE\Plugins" /Y
-</Command>
+      <Command>copy "$(TargetPath)" "H:\mo2\fo4vr\mods\FRIK_69\F4SE\Plugins" /Y
+copy "$(SolutionDir)x64\Release\FRIK.pdb" "H:\mo2\fo4vr\mods\FRIK_69\F4SE\Plugins" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Fallout4VR_Body.vcxproj
+++ b/Fallout4VR_Body.vcxproj
@@ -139,8 +139,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(TargetPath)" "C:\mo2\fo4vr\mods\FRIK\F4SE\Plugins" /Y
-copy "$(TargetPath)" "C:\mo2\mgc\mods\FRIK alpha 64\F4SE\Plugins" /Y</Command>
+      <Command>copy "$(TargetPath)" "C:\Stuff\Fallout Modding\VR Essentials Overhaul\mods\FRIK alpha 71\F4SE\Plugins" /Y
+</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -167,8 +167,8 @@ copy "$(TargetPath)" "C:\mo2\mgc\mods\FRIK alpha 64\F4SE\Plugins" /Y</Command>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(TargetPath)" "H:\mo2\fo4vr\mods\FRIK_69\F4SE\Plugins" /Y
-copy "$(SolutionDir)x64\Release\FRIK.pdb" "H:\mo2\fo4vr\mods\FRIK_69\F4SE\Plugins" /Y</Command>
+      <Command>copy "$(TargetPath)" "C:\Stuff\Fallout Modding\VR Essentials Overhaul\mods\FRIK alpha 71\F4SE\Plugins" /Y
+</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Skeleton.h
+++ b/Skeleton.h
@@ -390,7 +390,6 @@ namespace F4VRBody
 		std::map<std::string, bool, CaseInsensitiveComparator> _closedHand;
 		std::map<std::string, vr::EVRButtonId, CaseInsensitiveComparator> _handBonesButton;
 
-		bool _weaponEquipped;
 		NiTransform _weapSave;
 		NiTransform _customTransform;
 		bool _useCustomWeaponOffset = false;


### PR DESCRIPTION
Fix blurry of 3D objects rendering in specific on screen views (screenshots below):
1. PipBoy in "In Front" config
2. Transfer of items UI
3. All crafting UIs

repro: open one of the UIs and move your head. the 3D object looks really bad.

I bisect the bug to v67 release and then to [6b21c428](https://github.com/rollingrock/Fallout-4-VR-Body/commit/6b21c42860110ae3f43a60ec0eeaf4a7cd088948) change of `fixMelee` function in `Skeleton.cpp`. The reason it got worse there is because of "isMelee" check was passing for no equipped weapon. Probably because fists is a melee weapon and you can have grenades equipped.

But the reason for the bad UI is actually in `(*g_player)->Update(0.0f);` line. Removing it fixes the visual issue without any negative effects that I can tell.

Additional changes: I refactored the code to do less as we can return early if no weapon is drawn or if the weapon is not melee.

PipBoy:
![cap1](https://github.com/user-attachments/assets/534b4260-444f-4a94-82ff-afccc89e6421)
zoomed on rad gauge:
![cap2](https://github.com/user-attachments/assets/a8103423-e391-4405-858a-4dd176017573)
weapon crafting:
![cap3](https://github.com/user-attachments/assets/a2f87577-001a-4e5f-b783-5addb1fdf5bc)