### PR TITLE
Fix pipboy usage in weapon reposition

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -94,7 +94,7 @@ namespace F4VRBody {
 		disableInteriorSmoothingHorizontal = ini.GetBoolValue("SmoothMovementVR", "DisableInteriorSmoothingHorizontal", 1);
 
 		// weaponPositioning
-		//c_repositionMasterMode = ini.GetBoolValue("Fallout4VRBody", "EnableRepositionMode", false);       Enabled / Disabled via config mode
+		//c_weaponRepositionMasterMode = ini.GetBoolValue("Fallout4VRBody", "EnableRepositionMode", false);       Enabled / Disabled via config mode
 		holdDelay = (int)ini.GetLongValue("Fallout4VRBody", "HoldDelay", 1000);
 		repositionButtonID = (int)ini.GetLongValue("Fallout4VRBody", "RepositionButtonID", vr::EVRButtonId::k_EButton_SteamVR_Trigger); // 33
 		offHandActivateButtonID = (int)ini.GetLongValue("Fallout4VRBody", "OffHandActivateButtonID", vr::EVRButtonId::k_EButton_A); // 7
@@ -224,7 +224,7 @@ namespace F4VRBody {
 		rc = ini.SetBoolValue("Fallout4VRBody", "PipBoyTorchOnArm", isPipBoyTorchOnArm);
 		rc = ini.SetBoolValue("Fallout4VRBody", "EnableArmsOnlyMode", armsOnly);
 		rc = ini.SetBoolValue("Fallout4VRBody", "EnableStaticGripping", staticGripping);
-		//rc = ini.SetBoolValue("Fallout4VRBody", "EnableRepositionMode", c_repositionMasterMode);  Handled by Config Mode. 
+		//rc = ini.SetBoolValue("Fallout4VRBody", "EnableRepositionMode", c_weaponRepositionMasterMode);  Handled by Config Mode. 
 		rc = ini.SetBoolValue("Fallout4VRBody", "HideTheHead", hideHead);
 		rc = ini.SetDoubleValue("Fallout4VRBody", "handUI_X", handUI_X);
 		rc = ini.SetDoubleValue("Fallout4VRBody", "handUI_Y", handUI_Y);

--- a/ConfigurationMode.cpp
+++ b/ConfigurationMode.cpp
@@ -26,7 +26,6 @@ namespace F4VRBody {
 				MCConfigUI->m_parent->RemoveChild(MCConfigUI);
 			}
 			_skelly->disableConfigModePose();
-			SetINIFloat("fDirectionalDeadzone:Controls", c_repositionMasterMode ? 1.0 : g_config->directionalDeadzone);
 			_calibrateModeActive = false;
 		}
 	}
@@ -137,7 +136,7 @@ namespace F4VRBody {
 			g_config->dampenHands ? UIElement->m_localTransform.scale = 1 : UIElement->m_localTransform.scale = 0;
 			// Weapon Reposition Mode
 			UIElement = _skelly->getNode("MC-Tile08On", _skelly->getPlayerNodes()->primaryUIAttachNode);
-			c_repositionMasterMode ? UIElement->m_localTransform.scale = 1 : UIElement->m_localTransform.scale = 0;
+			UIElement->m_localTransform.scale = c_weaponRepositionMasterMode ? 1 : 0;
 			// Grip Mode
 			if (!g_config->enableGripButtonToGrap && !g_config->onePressGripButton && !g_config->enableGripButtonToLetGo) { // Standard Sticky Grip on / off
 				for (int i = 0; i < 4; i++) {
@@ -263,7 +262,8 @@ namespace F4VRBody {
 			}
 			if (WeaponButtonPressed && !_isWeaponButtonPressed) {
 				_isWeaponButtonPressed = true;
-				c_repositionMasterMode = !c_repositionMasterMode;
+				c_weaponRepositionMasterMode = !c_weaponRepositionMasterMode;
+				rotationStickEnabledToggle(!c_weaponRepositionMasterMode);
 			}
 			else if (!WeaponButtonPressed) {
 				_isWeaponButtonPressed = false;
@@ -356,6 +356,7 @@ namespace F4VRBody {
 
 	void ConfigurationMode::onUpdate() {
 		
+		checkWeaponRepositionPipboyConflict();
 		pipboyConfigurationMode();
 		mainConfigurationMode();
 
@@ -728,5 +729,16 @@ namespace F4VRBody {
 				}
 			}
 		}
+	}
+
+	/// <summary>
+	/// Check if currently in weapon reposition mode to enable or disable the rotation stick depending if pipboy is open.
+	/// Needed to operate vanilla in-fron or projected pipboy when also doing weapon repositioning.
+	/// On-wrist pipboy needs the rotation stick disabled to override its own UI.
+	/// </summary>
+	void ConfigurationMode::checkWeaponRepositionPipboyConflict() {
+		if (!c_weaponRepositionMasterMode)
+			return;
+		rotationStickEnabledToggle(isAnyPipboyOpen() && !g_pipboy->isOperatingPipboy());
 	}
 }

--- a/ConfigurationMode.h
+++ b/ConfigurationMode.h
@@ -35,6 +35,7 @@ namespace F4VRBody {
 		void configModeExit();
 		void pipboyConfigurationMode();
 		void mainConfigurationMode();
+		void checkWeaponRepositionPipboyConflict();
 
 		Skeleton* _skelly;
 		OpenVRHookManagerAPI* _vrhook;

--- a/F4VRBody.cpp
+++ b/F4VRBody.cpp
@@ -54,7 +54,7 @@ namespace F4VRBody {
 	bool _controlSleepStickyX = false;
 	bool _controlSleepStickyY = false;
 	bool _controlSleepStickyT = false;
-	bool c_repositionMasterMode = false;
+	bool c_weaponRepositionMasterMode = false;
 
 	std::map<std::string, NiTransform, CaseInsensitiveComparator> handClosed;
 	std::map<std::string, NiTransform, CaseInsensitiveComparator> handOpen;
@@ -1321,7 +1321,7 @@ namespace F4VRBody {
 			CALL_MEMBER_FN(*g_uiMessageManager, SendUIMessage)(menuName, kMessage_Close);
 		}
 
-		 c_repositionMasterMode = !c_repositionMasterMode;
+		 c_weaponRepositionMasterMode = !c_weaponRepositionMasterMode;
 	}
 
 	void dumpGeometryArray(StaticFunctionTag* base) {

--- a/F4VRBody.h
+++ b/F4VRBody.h
@@ -39,7 +39,7 @@ namespace F4VRBody {
 	extern bool _controlSleepStickyX;
 	extern bool _controlSleepStickyY;
 	extern bool _controlSleepStickyT;
-	extern bool c_repositionMasterMode;
+	extern bool c_weaponRepositionMasterMode;
 
 	class BoneSphere {
 	public:

--- a/Pipboy.cpp
+++ b/Pipboy.cpp
@@ -636,7 +636,8 @@ namespace F4VRBody {
 						if (root->GetVariable(&IsProjected, "root.Menu_mc.projectedBorder_mc.visible")) { //check if Pipboy is projected and disable right stick rotation if it isn't
 							bool UIProjected = IsProjected.GetBool();
 							if (!UIProjected && g_config->switchUIControltoPrimary) {
-								SetINIFloat("fDirectionalDeadzone:Controls", 1.0);  //prevents player movement controls so we can switch controls to the right stick (or left if the Pipboy is on the right arm)
+								//prevents player rotation controls so we can switch controls to the right stick (or left if the Pipboy is on the right arm)
+								rotationStickEnabledToggle(false); 
 							}
 						}
 						if (root->GetVariable(&PBCurrentPage, "root.Menu_mc.DataObj._CurrentPage")) {  // Get Current Pipboy Tab and store it.

--- a/Pipboy.h
+++ b/Pipboy.h
@@ -22,6 +22,9 @@ namespace F4VRBody {
 			return _pipboyStatus;
 		}
 
+		/// <summary>
+		/// True if on-wrist pipboy is open.
+		/// </summary>
 		inline bool isOperatingPipboy() const {
 			return _isOperatingPipboy; 
 		}

--- a/Skeleton.cpp
+++ b/Skeleton.cpp
@@ -2354,9 +2354,9 @@ namespace F4VRBody {
 						}
 						_pressLength = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - _repositionButtonHoldStart;
 						if (!_inRepositionMode && reg & vr::ButtonMaskFromId((vr::EVRButtonId)g_config->repositionButtonID) && _pressLength > g_config->holdDelay) {
-							if (_vrhook && c_repositionMasterMode)
+							if (_vrhook && c_weaponRepositionMasterMode)
 								_vrhook->StartHaptics(g_config->leftHandedMode ? 0 : 1, 0.1 * (_repositionMode + 1), 0.3);
-							_inRepositionMode = c_repositionMasterMode;
+							_inRepositionMode = c_weaponRepositionMasterMode;
 						}
 						else if (!(reg & vr::ButtonMaskFromId((vr::EVRButtonId)g_config->repositionButtonID))) {
 							_repositionButtonHolding = false;
@@ -2412,7 +2412,7 @@ namespace F4VRBody {
 						_offhandPos = _offhandFingerBonePos;
 						bodyPos = _curPos;
 						vr::VRControllerAxis_t axis_state = !(g_config->pipBoyButtonArm > 0) ? VRHook::g_vrHook->getControllerState(VRHook::VRSystem::TrackerType::Right).rAxis[0] : VRHook::g_vrHook->getControllerState(VRHook::VRSystem::TrackerType::Left).rAxis[0];
-						if (_repositionButtonHolding && c_repositionMasterMode) {
+						if (_repositionButtonHolding && c_weaponRepositionMasterMode) {
 							// this is for a preview of the move. The preview happens one frame before we detect the release so must be processed separately.
 							auto end = _offhandPos - _curPos;
 							auto change = vec3_len(end) > vec3_len(_startFingerBonePos) ? vec3_len(end - _startFingerBonePos) : -vec3_len(end - _startFingerBonePos);
@@ -2441,7 +2441,7 @@ namespace F4VRBody {
 							}
 						}
 						//_hasLetGoRepositionButton is always one frame after _repositionButtonHolding
-						if (_hasLetGoRepositionButton && _pressLength > 0 && _pressLength < g_config->holdDelay && c_repositionMasterMode) {
+						if (_hasLetGoRepositionButton && _pressLength > 0 && _pressLength < g_config->holdDelay && c_weaponRepositionMasterMode) {
 							_MESSAGE("Updating grip rotation for %s: powerArmor: %d", weapname, _inPowerArmor);
 							_customTransform.rot = weap->m_localTransform.rot;
 							_hasLetGoRepositionButton = false;
@@ -2449,7 +2449,7 @@ namespace F4VRBody {
 							g_weaponOffsets->addOffset(weapname, _customTransform, _inPowerArmor ? Mode::powerArmor : Mode::normal);
 							writeOffsetJson();
 						}
-						else if (_hasLetGoRepositionButton && _pressLength > 0 && _pressLength > g_config->holdDelay && c_repositionMasterMode) {
+						else if (_hasLetGoRepositionButton && _pressLength > 0 && _pressLength > g_config->holdDelay && c_weaponRepositionMasterMode) {
 							switch (_repositionMode) {
 							case weapon:
 								_MESSAGE("Saving position translation for %s from (%f, %f, %f) -> (%f, %f, %f): powerArmor: %d", weapname, weap->m_localTransform.pos.x, weap->m_localTransform.pos.y, weap->m_localTransform.pos.z, _offsetPreview.x, _offsetPreview.y, _offsetPreview.z, _inPowerArmor);
@@ -2570,7 +2570,7 @@ namespace F4VRBody {
             }
         }
 
-        if (c_repositionMasterMode) {
+        if (c_weaponRepositionMasterMode) {
             uint64_t _pressLength = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - _repositionButtonHoldStart;
 
             // Detect scope reposition button being held near scope. Only has to start near scope.
@@ -2594,10 +2594,10 @@ namespace F4VRBody {
             // Repositioning does not require hand near scope
             if (!_inRepositionMode && (handInput & vr::ButtonMaskFromId(static_cast<vr::EVRButtonId>(g_config->repositionButtonID))) && _pressLength > g_config->holdDelay) {
                 // Enter reposition mode
-                if (_vrhook && c_repositionMasterMode) {
+                if (_vrhook && c_weaponRepositionMasterMode) {
                     _vrhook->StartHaptics(g_config->leftHandedMode ? 0 : 1, 0.1, 0.3);
                 }
-                _inRepositionMode = c_repositionMasterMode;
+                _inRepositionMode = c_weaponRepositionMasterMode;
             } else if (_inRepositionMode) { // In reposition mode for better scopes
                 vr::VRControllerAxis_t axis_state = !(g_config->pipBoyButtonArm > 0) ? VRHook::g_vrHook->getControllerState(VRHook::VRSystem::TrackerType::Right).rAxis[0] : VRHook::g_vrHook->getControllerState(VRHook::VRSystem::TrackerType::Left).rAxis[0];
                 if (!_repositionModeSwitched && (handInput & vr::ButtonMaskFromId(static_cast<vr::EVRButtonId>(g_config->offHandActivateButtonID)))) {

--- a/utils.cpp
+++ b/utils.cpp
@@ -299,10 +299,25 @@ namespace F4VRBody {
 
 		set = GetINISetting("fPipboyScaleInnerAngle:VRPipboy");
 		set->SetDouble(5.0);
-		if (!c_repositionMasterMode) {
-			SetINIFloat("fDirectionalDeadzone:Controls", g_config->directionalDeadzone);  //restores player rotation to right stick
-		}
 
+		rotationStickEnabledToggle(true);
+	}
+
+	/// <summary>
+	/// Check if ANY pipboy open by checking if pipboy menu can be found in the UI.
+	/// Returns true for wrist, in-front, and projected pipboy.
+	/// </summary>
+	bool isAnyPipboyOpen() {
+		BSFixedString pipboyMenu("PipboyMenu");
+		return (*g_ui)->GetMenu(pipboyMenu) != nullptr;
+	}
+
+	/// <summary>
+	/// If to enable/disable the use of right stick for player rotattion.
+	/// Used to disable for pipboy usage and weapon repositions.
+	/// </summary>
+	void rotationStickEnabledToggle(bool enable) {
+		SetINIFloat("fDirectionalDeadzone:Controls", enable ? g_config->directionalDeadzone : 1.0);
 	}
 
 	// Function to check if the camera is looking at the object and the object is facing the camera

--- a/utils.h
+++ b/utils.h
@@ -57,6 +57,8 @@ namespace F4VRBody {
 
 	void turnPipBoyOn();
 	void turnPipBoyOff();
+	bool isAnyPipboyOpen();
+	void rotationStickEnabledToggle(bool enable);
 
 	bool isCameraLookingAtObject(NiAVObject* cameraNode, NiAVObject* objectNode, float detectThresh);
 


### PR DESCRIPTION
Fix not being able to operate in-front or projected pipboy when in weapon reposition mode.

caused by disabling the rotation stick but only enabling it for operating on-wrist pipboy