### PR TITLE
Use FRIK_MOD_PATH environment variable to copy build dll and pdb into mod folder.

### DIFF
--- a/Fallout4VR_Body.vcxproj
+++ b/Fallout4VR_Body.vcxproj
@@ -139,8 +139,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(TargetPath)" "C:\mo2\fo4vr\mods\FRIK\F4SE\Plugins" /Y
-copy "$(TargetPath)" "C:\mo2\mgc\mods\FRIK alpha 64\F4SE\Plugins" /Y</Command>
+      <Command>copy "$(TargetDir)$(TargetName).dll" "%FRIK_MOD_PATH%" /Y
+copy "$(TargetDir)$(TargetName).pdb" "%FRIK_MOD_PATH%" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -167,8 +167,8 @@ copy "$(TargetPath)" "C:\mo2\mgc\mods\FRIK alpha 64\F4SE\Plugins" /Y</Command>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(TargetPath)" "H:\mo2\fo4vr\mods\FRIK_69\F4SE\Plugins" /Y
-copy "$(SolutionDir)x64\Release\FRIK.pdb" "H:\mo2\fo4vr\mods\FRIK_69\F4SE\Plugins" /Y</Command>
+      <Command>copy "$(TargetDir)$(TargetName).dll" "%FRIK_MOD_PATH%" /Y
+copy "$(TargetDir)$(TargetName).pdb" "%FRIK_MOD_PATH%" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Prerequisites:
 2. Open `Fallout-4-VR-Body` in Visual Studio
    1. Double click `\root\Fallout-4-VR-Body\Fallout4VR_Body.sln`
 3. Change target dropdown from "Debug" to "Release"
-4. Build > Build Solution
-   1. Ignore post build error to copy output file
-5. Find `\root\Fallout-4-VR-Body\x64\Release\FRIK.dll`
+4. Setup post build copy environment variable
+   1. `setx FRIK_MOD_PATH "C:\[myModsLocation]\FRIK\F4SE\Plugins"`
+   2. Restart VS2022 to load the envar
+5. Build > Build Solution
+6. Find `\root\Fallout-4-VR-Body\x64\Release\FRIK.dll`
 
 ### Optional, build `f4sevr`:
 


### PR DESCRIPTION
So every dev can have different location without the need to change project file.