### PR TITLE
Improve performance of cullGeometry by reducing the amount of times we iterate over all the player geometries to only once a second and not every frame.

### DIFF
--- a/CullGeometryHandler.cpp
+++ b/CullGeometryHandler.cpp
@@ -1,0 +1,140 @@
+#include "Config.h"
+#include "Debug.h"
+#include "utils.h"
+
+namespace F4VRBody {
+
+	time_t _lastPreProcessTime = 0;
+	std::vector<int> _hideFaceSkinGeometryIndexes;
+	
+	// TODO: remove this in favor of ini setting
+	bool dumpArray = false;
+
+	/// <summary>
+	/// Hide/Show player specific equipment slot found by index.
+	/// </summary>
+	static void setEquipmentSlotByIndexVisibility(int slotId, bool toHide) {
+		auto& slot = (*g_player)->equipData->slots[slotId];
+
+		if (slot.item == nullptr || slot.node == nullptr)
+			return;
+
+		auto form_type = slot.item->GetFormType();
+		if (form_type != FormType::kFormType_ARMO)
+			return;
+
+		showHideNode(slot.node, toHide);
+	}
+
+	/// <summary>
+	/// Pre-calculate the indexes of the face and skin geometries to hide.
+	/// This is performance optimization to avoid iterating over all the geometries every frame by only doing it once per second.
+	/// It reduces the "cullPlayerGeometry" time from ~0.05ms to ~0.0002ms (for 89 frames, if framerate is 90).
+	/// May not sounds as much but total of this mod update frame is 0.25ms making it 20% of the time!
+	/// And god dammit the game is slow enough not to waste more time.
+	/// </summary>
+	static void preProcessHideGeometryIndexes(BSFadeNode* rn) {
+		auto now = std::time(nullptr);
+		if (now - _lastPreProcessTime < 1) {
+			return;
+		}
+		_lastPreProcessTime = now;
+
+		_hideFaceSkinGeometryIndexes.clear();
+		for (auto i = 0; i < rn->kGeomArray.count; i++) {
+			auto& geometry = rn->kGeomArray[i].spGeometry;
+			auto geomStr = str_tolower(trim(std::string(geometry->m_name.c_str())));
+
+			bool toHide = false;
+			if (g_config->hideHead) {
+				for (auto& faceGeom : g_config->faceGeometry) {
+					if (geomStr.find(faceGeom) != std::string::npos) {
+						toHide = true;
+						break;
+					}
+				}
+			}
+
+			if (g_config->hideSkin && !toHide) {
+				for (auto& skinGeom : g_config->skinGeometry) {
+					if (geomStr.find(skinGeom) != std::string::npos) {
+						toHide = true;
+						break;
+					}
+				}
+			}
+
+			// in case it was hidden before and shouldn't be anymore
+			showHideNode(geometry, false);
+
+			if (toHide) {
+				_hideFaceSkinGeometryIndexes.push_back(i);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Hide player face/skins geometries and equipment slots.
+	/// Face is things like eyes, mouth, hair, etc.
+	/// Equipment slots are things like helmet, glasses, etc.
+	/// </summary>
+	void cullPlayerGeometry() {
+		if (c_selfieMode && g_config->selfieIgnoreHideFlags) {
+			restoreGeometry();
+			return;
+		}
+
+		BSFadeNode* rn = static_cast<BSFadeNode*>((*g_player)->unkF0->rootNode);
+		if (!rn) {
+			return;
+		}
+
+		// check for selfie mode to handle an edge-case where all hide setting are set to false but the geometries are not restored
+		// preProcessHideGeometryIndexes will restore them (even equipment) so it's a hacky fix
+		if (g_config->hideHead || g_config->hideSkin || c_selfieMode) {
+			preProcessHideGeometryIndexes(rn);
+			for each(int idx in _hideFaceSkinGeometryIndexes) {
+				showHideNode(rn->kGeomArray[idx].spGeometry, true);
+			}
+		}
+		
+		if (g_config->hideEquipment) {
+			for (auto slot : g_config->hideEquipSlotIndexes) {
+				setEquipmentSlotByIndexVisibility(slot, true);
+			}
+		}
+
+		if (dumpArray) {
+			dumpArray = false;
+			dumpPlayerGeometry(rn);
+		}
+	}
+
+	/// <summary>
+	/// Show all player geometries and equipment slots.
+	/// </summary>
+	void restoreGeometry() {
+		//Face and Skin
+		BSFadeNode* rn = static_cast<BSFadeNode*>((*g_player)->unkF0->rootNode);
+		if (rn) {
+			for (auto i = 0; i < rn->kGeomArray.count; ++i) {
+				showHideNode(rn->kGeomArray[i].spGeometry, false);
+			}
+		}
+
+		//Equipment
+		setEquipmentSlotByIndexVisibility(0, false);
+		setEquipmentSlotByIndexVisibility(1, false);
+		setEquipmentSlotByIndexVisibility(2, false);
+		setEquipmentSlotByIndexVisibility(16, false);
+		setEquipmentSlotByIndexVisibility(17, false);
+		setEquipmentSlotByIndexVisibility(18, false);
+		setEquipmentSlotByIndexVisibility(19, false);
+		setEquipmentSlotByIndexVisibility(20, false);
+		setEquipmentSlotByIndexVisibility(22, false);
+	}
+
+	void dumpGeometryArray(StaticFunctionTag* base) {
+		dumpArray = true;
+	}
+}

--- a/CullGeometryHandler.h
+++ b/CullGeometryHandler.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace F4VRBody {
+	void cullPlayerGeometry();
+	void restoreGeometry();
+
+	// TODO: remove this in favor of ini setting
+	void dumpGeometryArray(StaticFunctionTag* base);
+}

--- a/Debug.h
+++ b/Debug.h
@@ -8,5 +8,6 @@ namespace F4VRBody {
 	void printNodes(NiNode* nde);
 	void printChildren(NiNode* child, std::string padding);
 	void printNodes(NiNode* nde, long long curTime);
+	void dumpPlayerGeometry(BSFadeNode* rn);
 	void debug(Skeleton* skelly);
 }

--- a/Fallout4VR_Body.vcxproj
+++ b/Fallout4VR_Body.vcxproj
@@ -175,6 +175,7 @@ copy "$(TargetDir)$(TargetName).pdb" "%FRIK_MOD_PATH%" /Y</Command>
     <ClCompile Include="BSFlattenedBoneTree.cpp" />
     <ClCompile Include="Config.cpp" />
     <ClCompile Include="ConfigurationMode.cpp" />
+    <ClCompile Include="CullGeometryHandler.cpp" />
     <ClCompile Include="Debug.cpp" />
     <ClCompile Include="F4VRBody.cpp" />
     <ClCompile Include="GunReload.cpp" />
@@ -206,6 +207,7 @@ copy "$(TargetDir)$(TargetName).pdb" "%FRIK_MOD_PATH%" /Y</Command>
     <ClInclude Include="BSFlattenedBoneTree.h" />
     <ClInclude Include="Config.h" />
     <ClInclude Include="ConfigurationMode.h" />
+    <ClInclude Include="CullGeometryHandler.h" />
     <ClInclude Include="Debug.h" />
     <ClInclude Include="F4VRBody.h" />
     <ClInclude Include="GunReload.h" />

--- a/Fallout4VR_Body.vcxproj.filters
+++ b/Fallout4VR_Body.vcxproj.filters
@@ -81,6 +81,9 @@
     <ClCompile Include="Debug.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="CullGeometryHandler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="hook.h">
@@ -184,6 +187,9 @@
     </ClInclude>
     <ClInclude Include="include\SimpleIni.h">
       <Filter>Include Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CullGeometryHandler.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/debug.cpp
+++ b/debug.cpp
@@ -81,6 +81,17 @@ namespace F4VRBody {
 		}
 	}
 
+	/// <summary>
+	/// Dump the player body parts and whatever they are hidden.
+	/// </summary>
+	void dumpPlayerGeometry(BSFadeNode* rn) {
+		for (auto i = 0; i < rn->kGeomArray.count; ++i) {
+			auto& geometry = rn->kGeomArray[i].spGeometry;
+			auto geometryName = geometry->m_name.c_str();
+			_MESSAGE("Player Geometry at %d: '%s' isHidden? %d", i, geometryName, geometry->flags &= 0x1);
+		}
+	}
+
 	void debug(Skeleton* skelly) {
 
 		static std::uint64_t fc = 0;

--- a/utils.cpp
+++ b/utils.cpp
@@ -321,6 +321,16 @@ namespace F4VRBody {
 		SetINIFloat("fDirectionalDeadzone:Controls", enable ? g_config->directionalDeadzone : 1.0);
 	}
 
+	/// <summary>
+	/// Update the node flags to show/hide it.
+	/// </summary>
+	void showHideNode(NiAVObject* node, bool toHide) {
+		if (toHide)
+			node->flags |= 0x1; // hide
+		else
+			node->flags &= 0xfffffffffffffffe; // show
+	}
+
 	// Function to check if the camera is looking at the object and the object is facing the camera
 	bool isCameraLookingAtObject(NiAVObject* cameraNode, NiAVObject* objectNode, float detectThresh) {
 		// Get the position of the camera and the object

--- a/utils.h
+++ b/utils.h
@@ -60,6 +60,8 @@ namespace F4VRBody {
 	bool isAnyPipboyOpen();
 	void rotationStickEnabledToggle(bool enable);
 
+	void showHideNode(NiAVObject* node, bool toHide);
+
 	bool isCameraLookingAtObject(NiAVObject* cameraNode, NiAVObject* objectNode, float detectThresh);
 
 	bool getLeftHandedMode();


### PR DESCRIPTION
It reduces the "cullPlayerGeometry" time from ~0.05ms to ~0.0002ms (for 89 frames, if framerate is 90).
May not sounds as much but total of this mod update frame is 0.25ms making it 20% of the time!
And god dammit the game is slow enough not to waste more time.

And refactor the code into it's own handler