### PR TITLE
Bug fix: right hand incorrect positioning in left handed mode when a throwable weapon is equipped.

### DIFF
--- a/Skeleton.cpp
+++ b/Skeleton.cpp
@@ -1664,12 +1664,12 @@ namespace F4VRBody {
         }
 
         NiNode* rightWeapon = getNode("Weapon", (*g_player)->firstPersonSkeleton->GetAsNiNode());
-        NiNode* leftWeapon = getNode("WeaponLeft", (*g_player)->firstPersonSkeleton->GetAsNiNode());
-
+		NiNode* leftWeapon = _playerNodes->WeaponLeftNode; // "WeaponLeft" can return incorect node for left-handed with throwable weapons
+		
         bool handleLeftMode = g_config->leftHandedMode ^ isLeft;
 
         NiNode* weaponNode = handleLeftMode ? leftWeapon : rightWeapon;
-        NiNode* offsetNode = handleLeftMode ? _playerNodes->SecondaryMeleeWeaponOffsetNode2 : _playerNodes->primaryWeaponOffsetNOde;
+		NiNode* offsetNode = handleLeftMode ? _playerNodes->SecondaryMeleeWeaponOffsetNode2 : _playerNodes->primaryWeaponOffsetNOde;
 
         if (handleLeftMode) {
             _playerNodes->SecondaryMeleeWeaponOffsetNode2->m_localTransform = _playerNodes->primaryWeaponOffsetNOde->m_localTransform;
@@ -1719,10 +1719,10 @@ namespace F4VRBody {
 
         weaponNode->m_localTransform.pos = g_config->leftHandedMode ? (isLeft ? NiPoint3(3.389, -2.099, 3.133) : NiPoint3(0, -4.8, 0)) : (isLeft ? NiPoint3(0, 0, 0) : NiPoint3(6.389, -2.099, -3.133));
 
-        dampenHand(offsetNode, isLeft);
-
-        weaponNode->IncRef();
-        set1stPersonArm(weaponNode, offsetNode);
+		dampenHand(offsetNode, isLeft);
+			
+		weaponNode->IncRef();
+		set1stPersonArm(weaponNode, offsetNode);
 
         NiPoint3 handPos = isLeft ? _leftHand->m_worldTransform.pos : _rightHand->m_worldTransform.pos;
         NiMatrix43 handRot = isLeft ? _leftHand->m_worldTransform.rot : _rightHand->m_worldTransform.rot;


### PR DESCRIPTION
Reason: equipping throwable weapon adds another "WeaponLeft" node to the skeleton left arm. this result in what was supposed to be right arm node (for left-handed) to be left arm node. Which results in very incorrect right-hand position.
The extra node stays in the skeleton even when unequipping the throwable. That's why only restarting fixed the issue.

I've used `_playerNodes->WeaponLeftNode` instead of searching for the node by name as it looks to do the correct thing. The other option is to search for it under the right arm like so:
```
auto fpSkelly = (*g_player)->firstPersonSkeleton->GetAsNiNode();
auto leftWeaponFindRoot = g_config->leftHandedMode ? getNode( "RArm_Collarbone", fpSkelly) : fpSkelly;
NiNode* leftWeapon = getNode("WeaponLeft", leftWeaponFindRoot);
```
in case there is a problem we can change to this code.

P.S. this was the longest I've ever invested for a one-line fix  ¯\(°_o)/¯