### PR TITLE
Fix crash entering/leaving PA

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -1,8 +1,10 @@
-#include "Config.h"
 #include "include/SimpleIni.h"
+#include "include/json.hpp"
+#include <fstream>
+
+#include "Config.h"
 #include "utils.h"
 #include "resource.h"
-#include "include/json.hpp"
 
 using json = nlohmann::json;
 

--- a/ConfigurationMode.cpp
+++ b/ConfigurationMode.cpp
@@ -3,10 +3,9 @@
 #include "Skeleton.h"
 #include "Pipboy.h"
 #include "HandPose.h"
+#include "F4VRBody.h"
 
 namespace F4VRBody {
-
-	ConfigurationMode* g_configurationMode = nullptr;
 
 	/// <summary>
 	/// Exit Main FRIK Config Mode

--- a/ConfigurationMode.h
+++ b/ConfigurationMode.h
@@ -76,17 +76,4 @@ namespace F4VRBody {
 		float _cameraHeight_bkup = 0;
 		float _PACameraHeight_bkup = 0;
 	};
-
-	// Not a fan of globals but it may be easiest to refactor code right now
-	extern ConfigurationMode* g_configurationMode;
-
-	static void initConfigurationMode(Skeleton* skelly, OpenVRHookManagerAPI* hook) {
-		if (g_configurationMode) {
-			_MESSAGE("Delete existing configuration mode handler");
-			delete g_configurationMode;
-		}
-
-		_MESSAGE("Init configuration mode...");
-		g_configurationMode = new ConfigurationMode(skelly, hook);
-	}
 }

--- a/CullGeometryHandler.cpp
+++ b/CullGeometryHandler.cpp
@@ -1,14 +1,15 @@
+#include "CullGeometryHandler.h"
 #include "Config.h"
 #include "Debug.h"
 #include "utils.h"
 
 namespace F4VRBody {
-
-	time_t _lastPreProcessTime = 0;
-	std::vector<int> _hideFaceSkinGeometryIndexes;
+	CullGeometryHandler* g_cullGeometry = nullptr;
 	
-	// TODO: remove this in favor of ini setting
 	bool dumpArray = false;
+	void dumpGeometryArray(StaticFunctionTag* base) {
+		dumpArray = true;
+	}
 
 	/// <summary>
 	/// Hide/Show player specific equipment slot found by index.
@@ -33,7 +34,7 @@ namespace F4VRBody {
 	/// May not sounds as much but total of this mod update frame is 0.25ms making it 20% of the time!
 	/// And god dammit the game is slow enough not to waste more time.
 	/// </summary>
-	static void preProcessHideGeometryIndexes(BSFadeNode* rn) {
+	void CullGeometryHandler::preProcessHideGeometryIndexes(BSFadeNode* rn) {
 		auto now = std::time(nullptr);
 		if (now - _lastPreProcessTime < 1) {
 			return;
@@ -78,7 +79,7 @@ namespace F4VRBody {
 	/// Face is things like eyes, mouth, hair, etc.
 	/// Equipment slots are things like helmet, glasses, etc.
 	/// </summary>
-	void cullPlayerGeometry() {
+	void CullGeometryHandler::cullPlayerGeometry() {
 		if (c_selfieMode && g_config->selfieIgnoreHideFlags) {
 			restoreGeometry();
 			return;
@@ -113,7 +114,7 @@ namespace F4VRBody {
 	/// <summary>
 	/// Show all player geometries and equipment slots.
 	/// </summary>
-	void restoreGeometry() {
+	void CullGeometryHandler::restoreGeometry() {
 		//Face and Skin
 		BSFadeNode* rn = static_cast<BSFadeNode*>((*g_player)->unkF0->rootNode);
 		if (rn) {
@@ -132,9 +133,5 @@ namespace F4VRBody {
 		setEquipmentSlotByIndexVisibility(19, false);
 		setEquipmentSlotByIndexVisibility(20, false);
 		setEquipmentSlotByIndexVisibility(22, false);
-	}
-
-	void dumpGeometryArray(StaticFunctionTag* base) {
-		dumpArray = true;
 	}
 }

--- a/CullGeometryHandler.cpp
+++ b/CullGeometryHandler.cpp
@@ -2,10 +2,9 @@
 #include "Config.h"
 #include "Debug.h"
 #include "utils.h"
+#include "F4VRBody.h"
 
 namespace F4VRBody {
-	CullGeometryHandler* g_cullGeometry = nullptr;
-	
 	bool dumpArray = false;
 	void dumpGeometryArray(StaticFunctionTag* base) {
 		dumpArray = true;

--- a/CullGeometryHandler.h
+++ b/CullGeometryHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "utils.h"
+#include "f4se/PapyrusNativeFunctions.h"
+#include "f4se/NiNodes.h"
 
 namespace F4VRBody {
 	// TODO: remove this in favor of ini setting
@@ -18,16 +19,4 @@ namespace F4VRBody {
 		time_t _lastPreProcessTime = 0;
 		std::vector<int> _hideFaceSkinGeometryIndexes;
 	};
-
-	// Not a fan of globals but it may be easiest to refactor code right now
-	extern CullGeometryHandler* g_cullGeometry;
-
-	static void initCullGeometryHandler() {
-		if (g_cullGeometry) {
-			delete g_cullGeometry;
-		}
-
-		_MESSAGE("Init configuration mode...");
-		g_cullGeometry = new CullGeometryHandler();
-	}
 }

--- a/CullGeometryHandler.h
+++ b/CullGeometryHandler.h
@@ -1,9 +1,33 @@
 #pragma once
 
-namespace F4VRBody {
-	void cullPlayerGeometry();
-	void restoreGeometry();
+#include "utils.h"
 
+namespace F4VRBody {
 	// TODO: remove this in favor of ini setting
 	void dumpGeometryArray(StaticFunctionTag* base);
+
+	class CullGeometryHandler
+	{
+	public:
+		void cullPlayerGeometry();
+	
+	private:
+		void restoreGeometry();
+		void preProcessHideGeometryIndexes(BSFadeNode* rn);
+
+		time_t _lastPreProcessTime = 0;
+		std::vector<int> _hideFaceSkinGeometryIndexes;
+	};
+
+	// Not a fan of globals but it may be easiest to refactor code right now
+	extern CullGeometryHandler* g_cullGeometry;
+
+	static void initCullGeometryHandler() {
+		if (g_cullGeometry) {
+			delete g_cullGeometry;
+		}
+
+		_MESSAGE("Init configuration mode...");
+		g_cullGeometry = new CullGeometryHandler();
+	}
 }

--- a/F4VRBody.h
+++ b/F4VRBody.h
@@ -12,9 +12,11 @@
 #include "f4se/PapyrusVM.h"
 //#include "f4se/GameForms.h"
 
-#include "include/SimpleIni.h"
 #include "SmoothMovementVR.h"
 #include "Offsets.h"
+#include "Pipboy.h"
+#include "ConfigurationMode.h"
+#include "CullGeometryHandler.h"
 
 #include <windows.h>
 
@@ -23,8 +25,11 @@ extern F4SEPapyrusInterface* g_papyrus;
 extern F4SEMessagingInterface* g_messaging;
 
 
-
 namespace F4VRBody {
+	
+	extern Pipboy* g_pipboy;
+	extern ConfigurationMode* g_configurationMode;
+	extern CullGeometryHandler* g_cullGeometry;
 
 	// TODO: bad global state variable that should be refactored
 	extern bool c_isLookingThroughScope;

--- a/Pipboy.cpp
+++ b/Pipboy.cpp
@@ -3,6 +3,7 @@
 #include "Config.h"
 #include "utils.h"
 #include "VR.h"
+#include "F4VRBody.h"
 
 #include <chrono>
 #include <time.h>
@@ -11,8 +12,6 @@
 using namespace std::chrono;
 
 namespace F4VRBody {
-
-	Pipboy* g_pipboy = nullptr;
 
 	void Pipboy::swapPipboy() {
 		_pipboyStatus = false;
@@ -184,7 +183,7 @@ namespace F4VRBody {
 		if (pipOnButtonPressed && !_stickybpip && !_isOperatingPipboy) {
 			_stickybpip = true;
 			_controlSleepStickyT = true;
-			std::thread t5(SecondaryTriggerSleep, 300); // switches a bool to false after 150ms
+			std::thread t5(&Pipboy::SecondaryTriggerSleep, this, 300); // switches a bool to false after 150ms
 			t5.detach();
 		}
 		else if (!pipOnButtonPressed) {
@@ -376,7 +375,6 @@ namespace F4VRBody {
 			}
 		}
 	}
-
 
 	/* ==============================================PIPBOY CONTOLS================================================================================
 	//
@@ -778,7 +776,7 @@ namespace F4VRBody {
 										_controlSleepStickyY = true;
 										std::thread t1(SimulateExtendedButtonPress, VK_UP); // Scroll up list
 										t1.detach();
-										std::thread t2(RightStickYSleep, 155);
+										std::thread t2(&Pipboy::RightStickYSleep, this, 155);
 										t2.detach();
 									}
 								}
@@ -787,7 +785,7 @@ namespace F4VRBody {
 										_controlSleepStickyY = true;
 										std::thread t1(SimulateExtendedButtonPress, VK_DOWN); // Scroll down list
 										t1.detach();
-										std::thread t2(RightStickYSleep, 155);
+										std::thread t2(&Pipboy::RightStickYSleep, this, 155);
 										t2.detach();
 									}
 								}
@@ -795,7 +793,7 @@ namespace F4VRBody {
 									if (!_controlSleepStickyX) {
 										_controlSleepStickyX = true;
 										root->Invoke("root.Menu_mc.gotoPrevTab", nullptr, nullptr, 0); // Next Sub Page
-										std::thread t3(RightStickXSleep, 170);
+										std::thread t3(&Pipboy::RightStickXSleep, this, 170);
 										t3.detach();
 									}
 								}
@@ -803,7 +801,7 @@ namespace F4VRBody {
 									if (!_controlSleepStickyX) {
 										_controlSleepStickyX = true;
 										root->Invoke("root.Menu_mc.gotoNextTab", nullptr, nullptr, 0); // Previous Sub Page
-										std::thread t3(RightStickXSleep, 170);
+										std::thread t3(&Pipboy::RightStickXSleep, this, 170);
 										t3.detach();
 									}
 								}
@@ -930,5 +928,29 @@ namespace F4VRBody {
 		//float dot = vec3_dot(vec3_norm(pipBoyOut), vec3_norm(lookDir));
 
 		//return dot < -(pipBoyLookAtGate);
+	}
+
+	/// <summary>
+	/// Prevents Continous Input from Right Stick X Axis
+	/// </summary>
+	void Pipboy::RightStickXSleep(int time) {
+		Sleep(time);
+		_controlSleepStickyX = false;
+	}
+
+	/// <summary>
+	/// Prevents Continous Input from Right Stick Y Axis
+	/// </summary>
+	void Pipboy::RightStickYSleep(int time) {
+		Sleep(time);
+		_controlSleepStickyY = false;
+	}
+
+	/// <summary>
+	/// Used to determine if secondary trigger received a long or short press
+	/// </summary>
+	void Pipboy::SecondaryTriggerSleep(int time) {
+		Sleep(time);
+		_controlSleepStickyT = false;
 	}
 }

--- a/Pipboy.h
+++ b/Pipboy.h
@@ -39,6 +39,9 @@ namespace F4VRBody {
 		void pipboyManagement();
 		void dampenPipboyScreen();
 		bool isLookingAtPipBoy();
+		void RightStickXSleep(int time);
+		void RightStickYSleep(int time);
+		void SecondaryTriggerSleep(int time);
 
 		Skeleton* _skelly;
 		OpenVRHookManagerAPI* _vrhook;
@@ -67,18 +70,9 @@ namespace F4VRBody {
 		bool _weaponStateDetected = false;
 		UInt32 _lastPipboyPage = 0;
 		float lastRadioFreq = 0.0;
+
+		bool _controlSleepStickyX = false;
+		bool _controlSleepStickyY = false;
+		bool _controlSleepStickyT = false;
 	};
-
-	// Not a fan of globals but it may be easiest to refactor code right now
-	extern Pipboy* g_pipboy;
-	
-	static void initPipboy(Skeleton* skelly, OpenVRHookManagerAPI* hook) {
-		if (g_pipboy) {
-			_MESSAGE("Delete existing pipboy handler");
-			delete g_pipboy;
-		}
-
-		_MESSAGE("Init pipboy...");
-		g_pipboy = new Pipboy(skelly, hook);
-	}
 }

--- a/utils.cpp
+++ b/utils.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include "f4se/PapyrusEvents.h"
 #include <filesystem>
+#include <fstream>
 
 #define PI 3.14159265358979323846
 
@@ -240,21 +241,6 @@ namespace F4VRBody {
 				SendInput(1, &input, sizeof(INPUT));
 			}
 		}
-	}
-
-	void RightStickXSleep(int time) { // Prevents Continous Input from Right Stick X Axis
-		Sleep(time);
-		_controlSleepStickyX = false;
-	}
-
-	void RightStickYSleep(int time) { // Prevents Continous Input from Right Stick Y Axis
-		Sleep(time);
-		_controlSleepStickyY = false;
-	}
-
-	void SecondaryTriggerSleep(int time) { // Used to determine if secondary trigger received a long or short press 
-		Sleep(time);
-		_controlSleepStickyT = false;
 	}
 
 	void turnPipBoyOn() {

--- a/utils.h
+++ b/utils.h
@@ -6,7 +6,6 @@
 #include "f4se/GameRTTI.h"
 #include "matrix.h"
 #include "Offsets.h"
-#include "F4VRBody.h"
 
 #include <chrono>
 
@@ -48,9 +47,6 @@ namespace F4VRBody {
 	void WindowFocus();
 	void TurnPlayerRadioOn(bool isActive);
 	void SimulateExtendedButtonPress(WORD vkey);
-	void RightStickXSleep(int time);
-	void RightStickYSleep(int time);
-	void SecondaryTriggerSleep(int time);
 	//void PipboyReopen();
 	void ShowMessagebox(std::string asText);
 	void ShowNotification(std::string asText);


### PR DESCRIPTION
Didn't realized skelly completly changes when switching between regular and PA. Need to reset globals to use the new skelly.
any cached data needs to be cleared (cull geometry)

+ Refactor globals a bit to have relativly close location for init and release on skelly change.